### PR TITLE
Global Context updates

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { MemoryRouter as Router, Routes, Route } from 'react-router-dom';
 import { app, BrowserWindow, shell, ipcMain } from 'electron';
-import { GlobalContext } from './context/globalContext';
 import WelcomePage from 'pages/WelcomePage';
 import DeviceSelectorPage from 'pages/DeviceSelectorPage';
 import EmulatorSelectorPage from 'pages/EmulatorSelectorPage';
@@ -26,79 +25,15 @@ import CloudSyncPage from 'pages/CloudSyncPage';
 
 import UninstallPage from 'pages/UninstallPage';
 
-
 import EndPage from 'pages/EndPage';
+import { GlobalContext, initialState } from './context/globalContext';
 
 import 'getbasecore/src/utils/reset/core_reset.scss';
 import 'getbasecore/src/utils/grid-layout/core_grid-layout.scss';
 import 'getbasecore/src/components/atoms/Typography/core_typography.scss';
 
 export default function App() {
-  const [state, setState] = useState({
-    version:'',
-    branch: 'beta',
-    command: '',
-    debug: false,
-    debugText: '',
-    second: false,
-    mode: '',
-    system: '',
-    device: '',
-    storage: '',
-    storagePath: '',
-    SDID: '',
-    bezels: true,
-    powerTools: false,
-    GyroDSU: false,
-    cloudSync:false,
-    sudoPass: '',
-    achievements: {
-      user: '',
-      pass: '',
-    },
-    ar: {
-      sega: '43',
-      snes: '43',
-      classic3d: '43',
-      dolphin: '43',
-    },
-    shaders: {
-      handhelds: false,
-      classic: false,
-    },
-    theme: 'EPICNOIR',
-    installEmus: {
-      ra: { id: 'ra', status: true, name: 'RetroArch' },
-      dolphin: { id: 'dolphin', status: true, name: 'Dolphin' },
-      primehacks: { id: 'primehacks', status: true, name: 'Prime Hacks' },
-      ppsspp: { id: 'ppsspp', status: true, name: 'PPSSPP' },
-      duckstation: { id: 'duckstation', status: true, name: 'DuckStation' },
-      citra: { id: 'citra', status: true, name: 'Citra' },
-      pcsx2: { id: 'pcsx2', status: true, name: 'PCSX2' },
-      rpcs3: { id: 'rpcs3', status: true, name: 'RPCS3' },
-      yuzu: { id: 'yuzu', status: true, name: 'Yuzu' },
-      xemu: { id: 'xemu', status: true, name: 'Xemu' },
-      cemu: { id: 'cemu', status: true, name: 'Cemu' },
-      srm: { id: 'srm', status: true, name: 'Steam Rom Manager Parsers' },
-    },
-    overwriteConfigEmus: {
-      ra: { id: 'ra', status: true, name: 'RetroArch' },
-      dolphin: { id: 'dolphin', status: true, name: 'Dolphin' },
-      primehacks: { id: 'primehacks', status: true, name: 'Prime Hacks' },
-      ppsspp: { id: 'ppsspp', status: true, name: 'PPSSPP' },
-      duckstation: { id: 'duckstation', status: true, name: 'DuckStation' },
-      citra: { id: 'citra', status: true, name: 'Citra' },
-      pcsx2: { id: 'pcsx2', status: true, name: 'PCSX2' },
-      rpcs3: { id: 'rpcs3', status: true, name: 'RPCS3' },
-      yuzu: { id: 'yuzu', status: true, name: 'Yuzu' },
-      xemu: { id: 'xemu', status: true, name: 'Xemu' },
-      cemu: { id: 'cemu', status: true, name: 'Cemu' },
-      srm: { id: 'srm', status: true, name: 'Steam Rom Manager Parsers' },
-    },
-  });
-
-
-
+  const [state, setState] = useState(initialState);
 
   return (
     <GlobalContext.Provider
@@ -164,10 +99,14 @@ export default function App() {
           <Route exact path="/gyrodsu" element={<GyroDSUPage />} />
           <Route exact path="/power-tools" element={<PowerToolsPage />} />
           <Route exact path="/chd-tool" element={<CHDToolPage />} />
-          <Route exact path="/tools-and-stuff" element={<ToolsAndStuffPage />} />
+          <Route
+            exact
+            path="/tools-and-stuff"
+            element={<ToolsAndStuffPage />}
+          />
           <Route exact path="/uninstall" element={<UninstallPage />} />
           <Route exact path="/update-emulators" element={<UpdateEmusPage />} />
-            <Route exact path="/cloud-sync" element={<CloudSyncPage />} />
+          <Route exact path="/cloud-sync" element={<CloudSyncPage />} />
           <Route exact path="/pegasus-theme" element={<PegasusThemePage />} />
           <Route exact path="/end" element={<EndPage />} />
         </Routes>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { MemoryRouter as Router, Routes, Route } from 'react-router-dom';
 import { app, BrowserWindow, shell, ipcMain } from 'electron';
 import WelcomePage from 'pages/WelcomePage';
@@ -26,22 +26,15 @@ import CloudSyncPage from 'pages/CloudSyncPage';
 import UninstallPage from 'pages/UninstallPage';
 
 import EndPage from 'pages/EndPage';
-import { GlobalContext, initialState } from './context/globalContext';
+import { GlobalContextProvider } from './context/globalContext';
 
 import 'getbasecore/src/utils/reset/core_reset.scss';
 import 'getbasecore/src/utils/grid-layout/core_grid-layout.scss';
 import 'getbasecore/src/components/atoms/Typography/core_typography.scss';
 
 export default function App() {
-  const [state, setState] = useState(initialState);
-
   return (
-    <GlobalContext.Provider
-      value={{
-        state,
-        setState,
-      }}
-    >
+    <GlobalContextProvider>
       <Router>
         <Routes>
           <Route exact path="/" element={<WelcomePage />} />
@@ -111,6 +104,6 @@ export default function App() {
           <Route exact path="/end" element={<EndPage />} />
         </Routes>
       </Router>
-    </GlobalContext.Provider>
+    </GlobalContextProvider>
   );
 }

--- a/src/renderer/context/globalContext.js
+++ b/src/renderer/context/globalContext.js
@@ -1,3 +1,0 @@
-import { createContext } from "react";
-
-export const GlobalContext = createContext(null);

--- a/src/renderer/context/globalContext.tsx
+++ b/src/renderer/context/globalContext.tsx
@@ -1,9 +1,17 @@
-import { createContext } from 'react';
+import {
+  Context,
+  createContext,
+  Dispatch,
+  FC,
+  SetStateAction,
+  useContext,
+  useState,
+} from 'react';
 import { GlobalState } from '.';
 
 export interface GlobalContextInterface {
   state: GlobalState;
-  setState: (state: any) => void;
+  setState: Dispatch<SetStateAction<GlobalState>>;
 }
 
 export const initialState: GlobalState = {
@@ -69,4 +77,23 @@ export const initialState: GlobalState = {
   },
 };
 
-export const GlobalContext = createContext<GlobalContextInterface>(null);
+export const GlobalContext = createContext<GlobalContextInterface>({
+  state: initialState,
+  setState: () => {},
+});
+
+// TODO: I shouldn't have to type JSX.Element here, but it's not working.
+export const GlobalContextProvider: FC<{ children: JSX.Element }> = ({
+  children,
+}) => {
+  const [state, setState] = useState(initialState);
+  return (
+    <GlobalContext.Provider value={{ state, setState }}>
+      {children}
+    </GlobalContext.Provider>
+  );
+};
+
+// TODO: fix this
+export const useGlobalContext: Context<GlobalContextInterface> = () =>
+  useContext(GlobalContext);

--- a/src/renderer/context/globalContext.tsx
+++ b/src/renderer/context/globalContext.tsx
@@ -1,5 +1,4 @@
 import {
-  Context,
   createContext,
   Dispatch,
   FC,
@@ -95,5 +94,4 @@ export const GlobalContextProvider: FC<{ children: JSX.Element }> = ({
 };
 
 // TODO: fix this
-export const useGlobalContext: Context<GlobalContextInterface> = () =>
-  useContext(GlobalContext);
+export const useGlobalContext = () => useContext(GlobalContext);

--- a/src/renderer/context/globalContext.tsx
+++ b/src/renderer/context/globalContext.tsx
@@ -1,0 +1,72 @@
+import { createContext } from 'react';
+import { GlobalState } from '.';
+
+export interface GlobalContextInterface {
+  state: GlobalState;
+  setState: (state: any) => void;
+}
+
+export const initialState: GlobalState = {
+  version: '',
+  branch: 'beta',
+  command: '',
+  debug: false,
+  debugText: '',
+  second: false,
+  mode: '',
+  system: '',
+  device: '',
+  storage: '',
+  storagePath: '',
+  SDID: '',
+  bezels: true,
+  powerTools: false,
+  GyroDSU: false,
+  cloudSync: false,
+  sudoPass: '',
+  achievements: {
+    user: '',
+    pass: '',
+  },
+  ar: {
+    sega: '43',
+    snes: '43',
+    classic3d: '43',
+    dolphin: '43',
+  },
+  shaders: {
+    handhelds: false,
+    classic: false,
+  },
+  theme: 'EPICNOIR',
+  installEmus: {
+    ra: { id: 'ra', status: true, name: 'RetroArch' },
+    dolphin: { id: 'dolphin', status: true, name: 'Dolphin' },
+    primehacks: { id: 'primehacks', status: true, name: 'Prime Hacks' },
+    ppsspp: { id: 'ppsspp', status: true, name: 'PPSSPP' },
+    duckstation: { id: 'duckstation', status: true, name: 'DuckStation' },
+    citra: { id: 'citra', status: true, name: 'Citra' },
+    pcsx2: { id: 'pcsx2', status: true, name: 'PCSX2' },
+    rpcs3: { id: 'rpcs3', status: true, name: 'RPCS3' },
+    yuzu: { id: 'yuzu', status: true, name: 'Yuzu' },
+    xemu: { id: 'xemu', status: true, name: 'Xemu' },
+    cemu: { id: 'cemu', status: true, name: 'Cemu' },
+    srm: { id: 'srm', status: true, name: 'Steam Rom Manager Parsers' },
+  },
+  overwriteConfigEmus: {
+    ra: { id: 'ra', status: true, name: 'RetroArch' },
+    dolphin: { id: 'dolphin', status: true, name: 'Dolphin' },
+    primehacks: { id: 'primehacks', status: true, name: 'Prime Hacks' },
+    ppsspp: { id: 'ppsspp', status: true, name: 'PPSSPP' },
+    duckstation: { id: 'duckstation', status: true, name: 'DuckStation' },
+    citra: { id: 'citra', status: true, name: 'Citra' },
+    pcsx2: { id: 'pcsx2', status: true, name: 'PCSX2' },
+    rpcs3: { id: 'rpcs3', status: true, name: 'RPCS3' },
+    yuzu: { id: 'yuzu', status: true, name: 'Yuzu' },
+    xemu: { id: 'xemu', status: true, name: 'Xemu' },
+    cemu: { id: 'cemu', status: true, name: 'Cemu' },
+    srm: { id: 'srm', status: true, name: 'Steam Rom Manager Parsers' },
+  },
+};
+
+export const GlobalContext = createContext<GlobalContextInterface>(null);

--- a/src/renderer/context/globalContext.tsx
+++ b/src/renderer/context/globalContext.tsx
@@ -93,5 +93,4 @@ export const GlobalContextProvider: FC<{ children: JSX.Element }> = ({
   );
 };
 
-// TODO: fix this
 export const useGlobalContext = () => useContext(GlobalContext);

--- a/src/renderer/context/index.d.ts
+++ b/src/renderer/context/index.d.ts
@@ -22,22 +22,7 @@ export interface EmuConfig {
   name: string;
 }
 
-export interface InstallEmus {
-  ra: EmuConfig;
-  dolphin: EmuConfig;
-  primehacks: EmuConfig;
-  ppsspp: EmuConfig;
-  duckstation: EmuConfig;
-  citra: EmuConfig;
-  pcsx2: EmuConfig;
-  rpcs3: EmuConfig;
-  yuzu: EmuConfig;
-  xemu: EmuConfig;
-  cemu: EmuConfig;
-  srm: EmuConfig;
-}
-
-export interface OverwriteConfigEmus {
+export interface EmuConfigs {
   ra: EmuConfig;
   dolphin: EmuConfig;
   primehacks: EmuConfig;
@@ -74,6 +59,6 @@ export interface GlobalState {
   ar: Ar;
   shaders: Shaders;
   theme: string;
-  installEmus: InstallEmus;
-  overwriteConfigEmus: OverwriteConfigEmus;
+  installEmus: EmuConfigs;
+  overwriteConfigEmus: EmuConfigs;
 }

--- a/src/renderer/context/index.d.ts
+++ b/src/renderer/context/index.d.ts
@@ -15,178 +15,41 @@ export interface Shaders {
   classic: boolean;
 }
 
-export interface Ra {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Dolphin {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Primehacks {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Ppsspp {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Duckstation {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Citra {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Pcsx2 {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Rpcs3 {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Yuzu {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Xemu {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Cemu {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Srm {
+// TODO: idk what to name this
+export interface EmuConfig {
   id: string;
   status: boolean;
   name: string;
 }
 
 export interface InstallEmus {
-  ra: Ra;
-  dolphin: Dolphin;
-  primehacks: Primehacks;
-  ppsspp: Ppsspp;
-  duckstation: Duckstation;
-  citra: Citra;
-  pcsx2: Pcsx2;
-  rpcs3: Rpcs3;
-  yuzu: Yuzu;
-  xemu: Xemu;
-  cemu: Cemu;
-  srm: Srm;
-}
-
-export interface Ra2 {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Dolphin2 {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Primehacks2 {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Ppsspp2 {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Duckstation2 {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Citra2 {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Pcsx22 {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Rpcs32 {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Yuzu2 {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Xemu2 {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Cemu2 {
-  id: string;
-  status: boolean;
-  name: string;
-}
-
-export interface Srm2 {
-  id: string;
-  status: boolean;
-  name: string;
+  ra: EmuConfig;
+  dolphin: EmuConfig;
+  primehacks: EmuConfig;
+  ppsspp: EmuConfig;
+  duckstation: EmuConfig;
+  citra: EmuConfig;
+  pcsx2: EmuConfig;
+  rpcs3: EmuConfig;
+  yuzu: EmuConfig;
+  xemu: EmuConfig;
+  cemu: EmuConfig;
+  srm: EmuConfig;
 }
 
 export interface OverwriteConfigEmus {
-  ra: Ra2;
-  dolphin: Dolphin2;
-  primehacks: Primehacks2;
-  ppsspp: Ppsspp2;
-  duckstation: Duckstation2;
-  citra: Citra2;
-  pcsx2: Pcsx22;
-  rpcs3: Rpcs32;
-  yuzu: Yuzu2;
-  xemu: Xemu2;
-  cemu: Cemu2;
-  srm: Srm2;
+  ra: EmuConfig;
+  dolphin: EmuConfig;
+  primehacks: EmuConfig;
+  ppsspp: EmuConfig;
+  duckstation: EmuConfig;
+  citra: EmuConfig;
+  pcsx2: EmuConfig;
+  rpcs3: EmuConfig;
+  yuzu: EmuConfig;
+  xemu: EmuConfig;
+  cemu: EmuConfig;
+  srm: EmuConfig;
 }
 
 export interface GlobalState {

--- a/src/renderer/context/index.d.ts
+++ b/src/renderer/context/index.d.ts
@@ -1,0 +1,216 @@
+export interface Achievements {
+  user: string;
+  pass: string;
+}
+
+export interface Ar {
+  sega: string;
+  snes: string;
+  classic3d: string;
+  dolphin: string;
+}
+
+export interface Shaders {
+  handhelds: boolean;
+  classic: boolean;
+}
+
+export interface Ra {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Dolphin {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Primehacks {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Ppsspp {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Duckstation {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Citra {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Pcsx2 {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Rpcs3 {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Yuzu {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Xemu {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Cemu {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Srm {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface InstallEmus {
+  ra: Ra;
+  dolphin: Dolphin;
+  primehacks: Primehacks;
+  ppsspp: Ppsspp;
+  duckstation: Duckstation;
+  citra: Citra;
+  pcsx2: Pcsx2;
+  rpcs3: Rpcs3;
+  yuzu: Yuzu;
+  xemu: Xemu;
+  cemu: Cemu;
+  srm: Srm;
+}
+
+export interface Ra2 {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Dolphin2 {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Primehacks2 {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Ppsspp2 {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Duckstation2 {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Citra2 {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Pcsx22 {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Rpcs32 {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Yuzu2 {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Xemu2 {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Cemu2 {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface Srm2 {
+  id: string;
+  status: boolean;
+  name: string;
+}
+
+export interface OverwriteConfigEmus {
+  ra: Ra2;
+  dolphin: Dolphin2;
+  primehacks: Primehacks2;
+  ppsspp: Ppsspp2;
+  duckstation: Duckstation2;
+  citra: Citra2;
+  pcsx2: Pcsx22;
+  rpcs3: Rpcs32;
+  yuzu: Yuzu2;
+  xemu: Xemu2;
+  cemu: Cemu2;
+  srm: Srm2;
+}
+
+export interface GlobalState {
+  version: string;
+  branch: string;
+  command: string;
+  debug: boolean;
+  debugText: string;
+  second: boolean;
+  mode: string;
+  system: string;
+  device: string;
+  storage: string;
+  storagePath: string;
+  SDID: string;
+  bezels: boolean;
+  powerTools: boolean;
+  GyroDSU: boolean;
+  cloudSync: boolean;
+  sudoPass: string;
+  achievements: Achievements;
+  ar: Ar;
+  shaders: Shaders;
+  theme: string;
+  installEmus: InstallEmus;
+  overwriteConfigEmus: OverwriteConfigEmus;
+}

--- a/src/renderer/pages/AspectRatio2DPage.js
+++ b/src/renderer/pages/AspectRatio2DPage.js
@@ -1,10 +1,10 @@
-import React, { useEffect, useState, useContext } from "react";
-import { GlobalContext } from "context/globalContext";
+import React, { useState, useContext } from "react";
+import { useGlobalContext } from "context/globalContext";
 
 import AspectRatio2D from "components/organisms/Wrappers/AspectRatio2D.js";
 
 const AspectRatio2DPage = () => {
-  const { state, setState } = useContext(GlobalContext);
+  const { state, setState } = useGlobalContext();
   const { bezels } = state;
   const [statePage, setStatePage] = useState({
     disabledNext: true,

--- a/src/renderer/pages/AspectRatio2DPage.js
+++ b/src/renderer/pages/AspectRatio2DPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from "react";
+import React, { useState, useEffect } from "react";
 import { useGlobalContext } from "context/globalContext";
 
 import AspectRatio2D from "components/organisms/Wrappers/AspectRatio2D.js";


### PR DESCRIPTION
- Groups state stuff in a newly renamed `globalContext.tsx`
- Adds cli generated `GlobalState` typescript interfaces
- Adds a `GlobalContextProvider` with default context values
- Adds a `useGlobalContext` helper hook that I can use to replace other instances of importing `useContext` & `GlobalContext`

text editor video demo:

https://user-images.githubusercontent.com/5377356/183276737-b67edd40-368e-4e05-b0ca-7255d6c31396.mov

