### PR TITLE
chore: Update devEngines to engines in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -264,7 +264,7 @@
   "collective": {
     "url": "https://opencollective.com/electron-react-boilerplate-594"
   },
-  "devEngines": {
+  "engines": {
     "node": ">=14.x",
     "npm": ">=7.x"
   },


### PR DESCRIPTION
Running npm install fails with:
```
npm --version
10.9.1
node --version
v20.11.0
npm install
npm error Invalid property "node"
```

This PR fixes the issue by renaming `devEngines` to `engines` in package.json as per the specification:
https://docs.npmjs.com/cli/v11/configuring-npm/package-json#engines